### PR TITLE
Fix pg-mem crashes when setval has three arguments instead of two

### DIFF
--- a/src/functions/sequence-fns.ts
+++ b/src/functions/sequence-fns.ts
@@ -66,4 +66,18 @@ export const sequenceFunctions: FunctionDefinition[] = [
         },
         impure: true,
     },
+    {
+        name: 'setval',
+        args: [Types.regclass, Types.integer, Types.bool],
+        returns: Types.integer,
+        implementation: (seqId: RegClass, val: number, increase: boolean) => {
+            const { seq, t } = getSeq(seqId);
+            if (typeof val !== 'number') {
+                throw new QueryError('Invalid setval() value');
+            }
+            seq.setValue(t, val, increase);
+            return val;
+        },
+        impure: true,
+    },
 ]

--- a/src/interfaces-private.ts
+++ b/src/interfaces-private.ts
@@ -771,7 +771,7 @@ export interface _ISequence extends _RelationBase {
     alter(t: _Transaction, opts: CreateSequenceOptions | AlterSequenceChange): this;
     nextValue(t: _Transaction): number;
     restart(t: _Transaction): void;
-    setValue(t: _Transaction, value: number): void;
+    setValue(t: _Transaction, value: number, increase?: boolean): void;
     currentValue(t: _Transaction): number;
     drop(t: _Transaction): void;
 }

--- a/src/schema/sequence.ts
+++ b/src/schema/sequence.ts
@@ -125,7 +125,7 @@ export class Sequence implements _ISequence {
         return v;
     }
 
-    setValue(t: _Transaction, value: number) {
+    setValue(t: _Transaction, value: number, increase: boolean = true) {
         if (value > this.max) {
             throw new QueryError(`reached maximum value of sequence "${this.name}"`);
         }
@@ -134,7 +134,7 @@ export class Sequence implements _ISequence {
         }
         const data: SeqData = {
             currval: value,
-            nextval: value + this.inc,
+            nextval: increase ? value + this.inc : value,
         };
         t.set(this.symbol, data);
     }

--- a/src/tests/sequence.spec.ts
+++ b/src/tests/sequence.spec.ts
@@ -77,9 +77,45 @@ describe('Sequences', () => {
         }])
     });
 
+    it('can query set value when increase is true', () => {
+        const res = many(`create sequence test;
+                    select setval('test', 41, true);
+                    select nextval('test');`);
+        expect(res).to.deep.equal([{
+            nextval: 42
+        }])
+    });
+
+    it('can query set value when increase is false', () => {
+        const res = many(`create sequence test;
+                    select setval('test', 41, false);
+                    select nextval('test');`);
+        expect(res).to.deep.equal([{
+            nextval: 41
+        }])
+    });
+
     it('can query current value', () => {
         const res = many(`create sequence test;
                     select setval('test', 42);
+                    select CURRval('test');`);
+        expect(res).to.deep.equal([{
+            currval: 42
+        }])
+    });
+
+    it('can query current value when increase is true', () => {
+        const res = many(`create sequence test;
+                    select setval('test', 42, true);
+                    select CURRval('test');`);
+        expect(res).to.deep.equal([{
+            currval: 42
+        }])
+    });
+
+    it('can query current value when increase is false', () => {
+        const res = many(`create sequence test;
+                    select setval('test', 42, false);
                     select CURRval('test');`);
         expect(res).to.deep.equal([{
             currval: 42


### PR DESCRIPTION
The current implementation only accepts [two arguments](https://github.com/oguimbal/pg-mem/blob/master/src/functions/sequence-fns.ts#L57). However, in Postgres, a `setval` can have [three arguments](https://www.postgresql.org/docs/current/functions-sequence.html), and when using such queries, the `pg-mem` crashes.

This PR fixes this problem.